### PR TITLE
Allow default event handling on excluded classes

### DIFF
--- a/src/ng-drag-scroll.js
+++ b/src/ng-drag-scroll.js
@@ -60,7 +60,7 @@
                     if(enabled){
                         for (var i= 0; i<excludedClasses.length; i++) {
                             if (angular.element(e.target).hasClass(excludedClasses[i])) {
-                                return false;
+                                return true;
                             }
                         }
 


### PR DESCRIPTION
Default event handling is prevented for the on-mousedown event of excludedClasses. 

For example, dragging with the mouse down and that this causes scrolling of a browser window is default behavior. This is being prevented.

This is bothersome when you also use other frameworks that rely on default behavior.
